### PR TITLE
Fixed placement when Scroll Past End is enabled

### DIFF
--- a/lib/Marker.js
+++ b/lib/Marker.js
@@ -1,10 +1,26 @@
 const etch = require('etch');
 const $ = etch.dom;
 
+var fontSize = atom.config.defaultSettings.editor.fontSize;
+var lineHeight = atom.config.defaultSettings.editor.lineHeight;
+
+if (atom.config.settings.editor.fontSize !== undefined){
+	fontSize = atom.config.settings.editor.fontSize;
+}
+if (atom.config.settings.editor.lineHeight !== undefined){
+	lineHeight = atom.config.settings.editor.lineHeight;
+}
+
+
 module.exports =
 class Marker {
 	constructor({layer, line}) {
-		var lineCount = layer.markerView.editor.getLineCount();
+		var linesScrollPastEnd = 0;
+		if (atom.config.settings.editor.scrollPastEnd){
+			linesScrollPastEnd = (atom.windowDimensions.height-96)/(fontSize*lineHeight);
+			console.log("Fontsize "+fontSize+" lineHeight "+lineHeight+" window height "+atom.windowDimensions.height)
+		}
+		var lineCount = layer.markerView.editor.getLineCount()+linesScrollPastEnd;
 		var percent = (line * 100) / lineCount;
 
 		this.style = {


### PR DESCRIPTION
Checks if atom.config.settings.editor.scrollPastEnd is enabled. Uses `atom.config.(settings|defaultSettings).editor.fontSize` and `atom.config.(settings|defaultSettings).editor.fontSize.lineHeight` to calculate better positions of the highlights. 
Above values are cached from the config. If you happen to change font size or line height, you will need to reload the editor.

Also when using GUI elements above/below text editor (e.g. menu bar), highlights are _slightly_ out of place. Possible fix - find out how many lines are displayed in current editor window and simply do 
`var lineCount = layer.markerView.editor.getLineCount()+visibleLineCount;`